### PR TITLE
GHC perf import module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,7 @@
     nixosModules.zfs-dataset-metrics = ./modules/zfs-dataset-metrics.nix;
     nixosModules.monitoring-prometheus = ./modules/monitoring-prometheus.nix;
     nixosModules.service-watchdog = ./modules/service-watchdog.nix;
+    nixosModules.ghc-perf-import = ./modules/ghc-perf-import.nix;
 
 
     nixosModules.hf-cert-1 = {

--- a/modules/ghc-perf-import.nix
+++ b/modules/ghc-perf-import.nix
@@ -1,0 +1,119 @@
+{lib, pkgs, config, ...}:
+let cfg = config.services.ghc-perf-import;
+in{
+  options.services.ghc-perf-import = {
+    enable = lib.mkEnableOption "Enable ghc-perf-import service";
+    gitlabToken = lib.mkOption{
+      type = lib.types.str;
+      description = "GitLab access token";
+    };
+    user = lib.mkOption{
+      type = lib.types.str;
+      default = "ghc_perf";
+    };
+    group = lib.mkOption{
+      type = lib.types.str;
+      default = "ghc_perf";
+    };
+    dbName = lib.mkOption{
+      type = lib.types.str;
+      default = "ghc_perf";
+    };
+    dbSchema = lib.mkOption{
+      type = lib.types.path;
+    };
+    gitlab-bot-package = lib.mkOption {
+      type = lib.types.package;
+      description = "The gitlab-bot package";
+    };
+    ghc-note-perf-import-package = lib.mkOption {
+      type = lib.types.package;
+      description = "The ghc-perf-import package";
+    };
+    git-package = lib.mkOption {
+      type = lib.types.package;
+      description = "git package";
+      default = pkgs.git;
+    };
+  };
+  config = lib.mkIf cfg.enable {
+
+    systemd.services.ghc-perf-import-gitlab-bot = {
+      description = "ghc-perf metric import bot";
+      script = ''
+        ghc-perf-import-service \
+          --gitlab-root=https://gitlab.haskell.org/ \
+          --access-token=${config.services.ghc-perf-import.gitlabToken} \
+          --conn-string=postgresql:///ghc_perf \
+          --port=7088
+      '';
+      path = [ cfg.git-package cfg.gitlab-bot-package cfg.ghc-note-perf-import-package ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        User = "${cfg.user}";
+        PermissionsStartOnly = true;
+        CacheDirectory = "ghc-perf";
+      };
+    };
+    systemd.services.ghc-note-perf-import = {
+      description = "Update ghc-perf metrics from perf notes";
+      preStart = ''
+    if ! ${pkgs.sudo}/bin/sudo -upostgres ${pkgs.postgresql}/bin/psql -lqtA | grep -q "^${cfg.dbName}|"; then
+      echo "Initializing schema..."
+      ${pkgs.sudo}/bin/sudo -upostgres ${pkgs.postgresql}/bin/psql \
+        -c "CREATE ROLE ghc_perf_web WITH LOGIN;" \
+        -c "CREATE ROLE ghc_perf WITH LOGIN;" \
+        -c "CREATE DATABASE ${cfg.dbName} WITH OWNER ghc_perf;"
+      ${pkgs.sudo}/bin/sudo -ughc_perf ${pkgs.postgresql}/bin/psql -U ghc_perf < ${cfg.dbSchema}
+      ${pkgs.sudo}/bin/sudo -upostgres ${pkgs.postgresql}/bin/psql \
+        -c "GRANT SELECT ON ALL TABLES IN SCHEMA public TO ghc_perf_web;"
+      echo "done."
+    fi
+      '';
+      script = ''
+    cd /var/cache/ghc-perf
+    if [ ! -d ghc ]; then
+      echo "cloning $(pwd)/ghc..."
+      ${cfg.git-package}/bin/git clone https://gitlab.haskell.org/ghc/ghc
+    fi
+    cd ghc
+
+    echo "updating $(pwd)/ghc..."
+    ${cfg.git-package}/bin/git pull
+    ${cfg.git-package}/bin/git fetch https://gitlab.haskell.org/ghc/ghc-performance-notes.git refs/notes/perf:refs/notes/ci/perf
+
+    echo "importing commits..."
+    perf-import-git -c postgresql:///${cfg.dbName} -d ghc master
+
+    echo "importing notes..."
+    perf-import-notes -c postgresql:///${cfg.dbName} -d ghc -R refs/notes/ci/perf
+      '';
+      path = [ pkgs.git cfg.ghc-note-perf-import-package ];
+      serviceConfig = {
+        User = "${cfg.user}";
+        PermissionsStartOnly = true;
+        CacheDirectory = "ghc-perf";
+      };
+    };
+  
+    systemd.timers.ghc-note-perf-import = {
+      description = "Periodically update ghc-perf metrics";
+      wants = [ "network.target" "postgresql.service" ];
+      after = [ "postgresql.service" ];
+      wantedBy = [ "multi-user.target" ];
+      timerConfig = {
+        OnCalendar = "*-*-* 3:00:00";
+        Unit = "ghc-note-perf-import.service";
+      };
+    };
+
+    users.users."${cfg.user}" = {
+      description = "User for ghc-perf import script";
+      isSystemUser = true;
+      group = cfg.group;
+    };
+
+    users.groups."${cfg.group}" = {};
+    
+  };
+}

--- a/modules/ghc-perf-import.nix
+++ b/modules/ghc-perf-import.nix
@@ -3,9 +3,9 @@ let cfg = config.services.ghc-perf-import;
 in{
   options.services.ghc-perf-import = {
     enable = lib.mkEnableOption "Enable ghc-perf-import service";
-    gitlabToken = lib.mkOption{
-      type = lib.types.str;
-      description = "GitLab access token";
+    gitlab-token-path = lib.mkOption{
+      type = lib.types.path;
+      description = "Path to file holding GitLab access token";
     };
     user = lib.mkOption{
       type = lib.types.str;
@@ -43,7 +43,7 @@ in{
       script = ''
         ghc-perf-import-service \
           --gitlab-root=https://gitlab.haskell.org/ \
-          --access-token=${config.services.ghc-perf-import.gitlabToken} \
+          --access-token-path=${config.services.ghc-perf-import.gitlab-token-path} \
           --conn-string=postgresql:///ghc_perf \
           --port=7088
       '';
@@ -95,7 +95,7 @@ in{
         CacheDirectory = "ghc-perf";
       };
     };
-  
+
     systemd.timers.ghc-note-perf-import = {
       description = "Periodically update ghc-perf metrics";
       wants = [ "network.target" "postgresql.service" ];
@@ -114,6 +114,6 @@ in{
     };
 
     users.groups."${cfg.group}" = {};
-    
+
   };
 }

--- a/test-os.nix
+++ b/test-os.nix
@@ -19,6 +19,7 @@ pkgs.testers.nixosTest {
       self.nixosModules.stackage-server
       self.nixosModules.casa-server
       self.nixosModules.service-watchdog
+      self.nixosModules.ghc-perf-import
       { sops.defaultSopsFile = ./test-sops-file.json;
         sops.age.keyFile = "/etc/test-age-key";
         environment.etc."test-age-key".source = ./test-age-key.txt;
@@ -70,6 +71,20 @@ pkgs.testers.nixosTest {
               echo '#!/bin/sh' > $out/bin/stackage-server-cron && chmod +x $out/bin/stackage-server-cron
               touch $out/run/config
             '';
+        };
+        services.ghc-perf-import = {
+          enable = true;
+          gitlab-bot-package = pkgs.writeShellScriptBin "gitlab-perf-import-service" "exit 0";
+          ghc-note-perf-import-package = pkgs.symlinkJoin {
+            name="ghc-perf-import";
+            paths=[(pkgs.writeShellScriptBin "perf-import-notes" "exit 0")
+                   (pkgs.writeShellScriptBin "perf-import-git" "exit 0")];
+          };
+          git-package =  (pkgs.writeShellScriptBin "git" "mkdir -p ghc;exit 0");
+          dbSchema = builtins.toFile "import.sql" ''
+          CREATE TABLE test ( id serial PRIMARY KEY);
+          '';
+          gitlabToken = "bla";
         };
       }
     ];
@@ -155,5 +170,14 @@ pkgs.testers.nixosTest {
     machine.wait_for_unit("stackage-server")
     machine.wait_for_open_port(3000)
     machine.succeed("curl --silent --max-time 5 http://localhost:3000/lts")
+    # ghc-note-perf-import
+    machine.succeed("systemctl cat ghc-note-perf-import.timer")
+    machine.succeed("systemctl is-enabled ghc-note-perf-import.timer")
+    machine.succeed("systemctl cat ghc-note-perf-import.service")
+    machine.succeed("systemctl start ghc-note-perf-import.service --wait")
+    machine.succeed("stat /var/cache/ghc-perf/ghc")
+    # ghc-perf-import gitlab bot
+    machine.succeed("systemctl cat ghc-perf-import-gitlab-bot.service")
+    machine.succeed("systemctl is-enabled ghc-perf-import-gitlab-bot.service")
   '';
 }

--- a/test-os.nix
+++ b/test-os.nix
@@ -84,7 +84,7 @@ pkgs.testers.nixosTest {
           dbSchema = builtins.toFile "import.sql" ''
           CREATE TABLE test ( id serial PRIMARY KEY);
           '';
-          gitlabToken = "bla";
+          gitlab-token-path = "/dev/null";
         };
       }
     ];


### PR DESCRIPTION
Module for [ghc-perf-import and gitlab bot](https://gitlab.haskell.org/ghc/ghc-perf-import/).
Service scripts are mostly copied for original repo. 
As for alerts and ghc-perf-web - I was planning on migrating them in separate PRs.